### PR TITLE
Support React 17 peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,8 +60,8 @@
     "webpack-dev-server": "^3.1.8"
   },
   "peerDependencies": {
-    "react": "^15.0.0-0 || ^16.0.0-0",
-    "react-dom": "^15.0.0-0 || ^16.0.0-0"
+    "react": "^15.0.0-0 || ^16.0.0-0 || ^17.0.0-0",
+    "react-dom": "^15.0.0-0 || ^16.0.0-0 || ^17.0.0-0"
   },
   "sideEffects": false,
   "dependencies": {}


### PR DESCRIPTION
Right now, npm will fail to install this alongside React 17 because it can't resolve a valid set of peer dependencies. This expands the range to support React 17.