### PR TITLE
allow react version 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,8 +60,8 @@
     "webpack-dev-server": "^3.1.8"
   },
   "peerDependencies": {
-    "react": "^15.0.0-0 || ^16.0.0-0" || ^17.0.0",
-    "react-dom": "^15.0.0-0 || ^16.0.0-0" || ^17.0.0"
+    "react": "^15.0.0-0 || ^16.0.0-0 || ^17.0.0",
+    "react-dom": "^15.0.0-0 || ^16.0.0-0 || ^17.0.0"
   },
   "sideEffects": false,
   "dependencies": {}

--- a/package.json
+++ b/package.json
@@ -60,8 +60,8 @@
     "webpack-dev-server": "^3.1.8"
   },
   "peerDependencies": {
-    "react": "^15.0.0-0 || ^16.0.0-0",
-    "react-dom": "^15.0.0-0 || ^16.0.0-0"
+    "react": "^15.0.0-0 || ^16.0.0-0" || ^17.0.0",
+    "react-dom": "^15.0.0-0 || ^16.0.0-0" || ^17.0.0"
   },
   "sideEffects": false,
   "dependencies": {}


### PR DESCRIPTION
When trying to install I get a peer dependency error, this PR should fix it

```
npm i react-progressive-image
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR!
npm ERR! While resolving: typescript@0.1.0
npm ERR! Found: react@17.0.2
npm ERR! node_modules/react
npm ERR!   react@"17.0.2" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer react@"^15.0.0-0 || ^16.0.0-0" from react-progressive-image@0.6.0
npm ERR! node_modules/react-progressive-image
npm ERR!   react-progressive-image@"*" from the root project
npm ERR!
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```